### PR TITLE
[BUGFIX] Add apiKey.google parameter in ext_conf_template.txt

### DIFF
--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -16,3 +16,5 @@ mmURL = cdn.rawgit.com/googlemaps/v3-utility-library/master/markermanager/src/ma
 ibURL = cdn.rawgit.com/googlemaps/js-info-bubble/gh-pages/src/infobubble.js
 # cat=basic; type=input; label=URL of OverlappingMarkerSpiderfier (without protocol-prefix)
 omURL = jawj.github.com/OverlappingMarkerSpiderfier/bin/oms.min.js
+# cat=basic; type=input; label=Google API Key
+apiKey.google =


### PR DESCRIPTION
You forgot to add those line in your last update. We couldn't edit the google map API Key
